### PR TITLE
CHORE: Bump dev version to 0.3.dev0

### DIFF
--- a/doc/changelog.d/94.changed.md
+++ b/doc/changelog.d/94.changed.md
@@ -1,0 +1,1 @@
+CHORE: Bump dev version to 0.3.dev0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-conceptev-core"
 description = "A Python wrapper for Ansys Conceptev core"
-version = "0.2.dev0"
+version = "0.3.dev0"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
As title says.
Should be performed after 0.2.0 is released.