### PR TITLE
Refactor concept creation process

### DIFF
--- a/doc/changelog.d/98.miscellaneous.md
+++ b/doc/changelog.d/98.miscellaneous.md
@@ -1,0 +1,1 @@
+Refactor concept creation process

--- a/examples/simple_workflow.py
+++ b/examples/simple_workflow.py
@@ -130,14 +130,21 @@ with app.get_http_client(token) as client:
     project = app.create_new_project(
         client, account_id, hpc_id, f"New Project +{datetime.datetime.now()}"
     )
-    print(f"ID of the created project: {project['id']}")
+    print(f"ID of the created project: {project['projectId']}")
+
+    # Create a concept with that project
+    concept = app.create_new_concept(
+        client, project["projectId"], f"New Concept +{datetime.datetime.now()}"
+    )
+    print(f"ID of the created concept: {concept['id']}")
+
 
 # ### Perform basic operations
 #
 # Perform basic operations on the design instance associated with the new project.
 
 # +
-design_instance_id = project["design_instance_id"]
+design_instance_id = concept["design_instance_id"]
 
 with app.get_http_client(token, design_instance_id) as client:
 

--- a/src/ansys/conceptev/core/app.py
+++ b/src/ansys/conceptev/core/app.py
@@ -148,7 +148,7 @@ def create_new_project(
     hpc_id: str,
     title: str,
     project_goal: str = "Created from the CLI",
-):
+) -> dict:
     """Create a project."""
     osm_url = auth.config["OCM_URL"]
     token = client.headers["Authorization"]
@@ -171,7 +171,7 @@ def create_new_concept(
     client: httpx.Client,
     project_id: str,
     title: str = f"CLI concept {datetime.datetime.now()}",
-):
+) -> dict:
     """Create a concept within an existing project."""
     osm_url = auth.config["OCM_URL"]
     token = client.headers["Authorization"]
@@ -221,7 +221,7 @@ def create_new_concept(
     return created_concept
 
 
-def get_concept_ids(client: httpx.Client):
+def get_concept_ids(client: httpx.Client) -> dict:
     """Get concept IDs."""
     concepts = get(client, "/concepts")
     return {concept["name"]: concept["id"] for concept in concepts}
@@ -240,7 +240,7 @@ def get_account_ids(token: str) -> dict:
     return accounts
 
 
-def get_default_hpc(token: str, account_id: str):
+def get_default_hpc(token: str, account_id: str) -> dict:
     """Get the default HPC ID."""
     ocm_url = auth.config["OCM_URL"]
     response = httpx.post(
@@ -259,7 +259,7 @@ def create_submit_job(
     account_id: str,
     hpc_id: str,
     job_name: str = "cli_job: " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-):
+) -> dict:
     """Create and then submit a job."""
     job_input = {
         "job_name": job_name,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -119,22 +119,11 @@ def test_delete(httpx_mock: HTTPXMock, client: httpx.Client):
 def test_create_new_project(httpx_mock: HTTPXMock, client: httpx.Client):
     client.params = []
     project_id = "project_id_123"
-    design_id = "design_id_123"
-    design_instance_id = "design_instance_123"
     account_id = "account_id_123"
     hpc_id = "hpc_id_123"
-    user_id = "user_id_123"
     title = "Testing Title"
-    product_id = "123"
-    mocked_concept = {"name": "new_mocked_concept"}
     mocked_project = {"projectId": project_id}
-    mocked_design = {
-        "designId": design_id,
-        "designInstanceList": [{"designInstanceId": design_instance_id}],
-        "projectId": project_id,
-        "productId": product_id,
-    }
-    mocked_user = {"userId": user_id}
+
     project_data = {
         "accountId": account_id,
         "hpcId": hpc_id,
@@ -146,21 +135,16 @@ def test_create_new_project(httpx_mock: HTTPXMock, client: httpx.Client):
         url=f"{ocm_url}/project/create", method="post", match_json=project_data, json=mocked_project
     )
 
-    httpx_mock.add_response(
-        url=f"{ocm_url}/product/list",
-        method="get",
-        json=[{"productId": product_id, "productName": "CONCEPTEV"}],
-    )
+    value = app.create_new_project(client, account_id, hpc_id, title)
+    assert value == mocked_project
 
-    design_data = {
-        "projectId": project_id,
-        "productId": product_id,
-        "designTitle": "Branch 1",
-    }
-    httpx_mock.add_response(
-        url=f"{ocm_url}/design/create", method="post", match_json=design_data, json=mocked_design
-    )
-    httpx_mock.add_response(url=f"{ocm_url}/user/details", method="post", json=mocked_user)
+
+def test_create_concept(httpx_mock: HTTPXMock, client: httpx.Client):
+    design_id = "design_id_123"
+    design_instance_id = "design_instance_123"
+    project_id = "project_id_123"
+    user_id = "user_id_123"
+    mocked_concept = {"name": "new_mocked_concept"}
 
     concept_data = {
         "capabilities_ids": [],
@@ -175,13 +159,38 @@ def test_create_new_project(httpx_mock: HTTPXMock, client: httpx.Client):
         "requirements_ids": [],
         "user_id": user_id,
     }
+    project_id = "project_id_123"
+    product_id = "123"
+    mocked_design = {
+        "designId": design_id,
+        "designInstanceList": [{"designInstanceId": design_instance_id}],
+        "projectId": project_id,
+        "productId": product_id,
+    }
+    mocked_user = {"userId": user_id}
+    httpx_mock.add_response(
+        url=f"{ocm_url}/product/list",
+        method="get",
+        json=[{"productId": product_id, "productName": "CONCEPTEV"}],
+    )
+    concept_title = "CLI concept"
+    design_data = {
+        "projectId": project_id,
+        "productId": product_id,
+        "designTitle": concept_title,
+    }
+    httpx_mock.add_response(
+        url=f"{ocm_url}/design/create", method="post", match_json=design_data, json=mocked_design
+    )
+    httpx_mock.add_response(url=f"{ocm_url}/user/details", method="post", json=mocked_user)
+
     httpx_mock.add_response(
         url=f"{conceptev_url}/concepts?design_instance_id={design_instance_id}",
         method="post",
         match_json=concept_data,
         json=mocked_concept,
     )
-    value = app.create_new_project(client, account_id, hpc_id, title)
+    value = app.create_new_concept(client, project_id, concept_title)
     assert value == mocked_concept
 
 


### PR DESCRIPTION
Up until now, create_new_project() creates a new project *and* a new concept

This PR splits the project creation and concept creation into separate functions.
* create_new_project() --> returns project
* create_new_concept() --> returns concept

The example script is also modified accordingly: examples/simple_workflow.py