### PR TITLE
Refactor product id getter

### DIFF
--- a/doc/changelog.d/104.miscellaneous.md
+++ b/doc/changelog.d/104.miscellaneous.md
@@ -1,0 +1,1 @@
+Refactor product id getter

--- a/examples/simple_workflow.py
+++ b/examples/simple_workflow.py
@@ -130,14 +130,21 @@ with app.get_http_client(token) as client:
     project = app.create_new_project(
         client, account_id, hpc_id, f"New Project +{datetime.datetime.now()}"
     )
-    print(f"ID of the created project: {project['id']}")
+    print(f"ID of the created project: {project['projectId']}")
+
+    # Create a concept with that project
+    concept = app.create_new_concept(
+        client, project["projectId"], f"New Concept +{datetime.datetime.now()}"
+    )
+    print(f"ID of the created concept: {concept['id']}")
+
 
 # ### Perform basic operations
 #
 # Perform basic operations on the design instance associated with the new project.
 
 # +
-design_instance_id = project["design_instance_id"]
+design_instance_id = concept["design_instance_id"]
 
 with app.get_http_client(token, design_instance_id) as client:
 

--- a/src/ansys/conceptev/core/app.py
+++ b/src/ansys/conceptev/core/app.py
@@ -167,6 +167,21 @@ def create_new_project(
     return created_project.json()
 
 
+def get_product_id(product_info, product_name):
+    """Get the product id for specific product name."""
+    product_id = None
+    for product in product_info:
+        if isinstance(product, dict):
+            if product["productName"] == product_name:
+                product_id = product["productId"]
+    if product_id is None:
+        raise Exception(
+            f"Failed to obtain product id of '{product_name}'. product_info={str(product_info)}"
+        )
+
+    return product_id
+
+
 def create_new_concept(
     client: httpx.Client,
     project_id: str,
@@ -176,12 +191,8 @@ def create_new_concept(
     osm_url = auth.config["OCM_URL"]
     token = client.headers["Authorization"]
 
-    product_ids = httpx.get(osm_url + "/product/list", headers={"Authorization": token})
-    product_id = [
-        product["productId"]
-        for product in product_ids.json()
-        if product["productName"] == "CONCEPTEV"
-    ][0]
+    product_info = httpx.get(osm_url + "/product/list", headers={"Authorization": token}).json()
+    product_id = get_product_id(product_info, "CONCEPTEV")
 
     design_data = {
         "projectId": project_id,


### PR DESCRIPTION
Initial implementation would from - time to time - lead to a "string index needs to be integer" error. This implementation avoids that situation.