### PR TITLE
CHORE: Bump development version to 0.5.dev0

### DIFF
--- a/doc/changelog.d/107.changed.md
+++ b/doc/changelog.d/107.changed.md
@@ -1,0 +1,1 @@
+CHORE: Bump development version to 0.5.dev0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-conceptev-core"
 description = "A Python wrapper for Ansys Conceptev core"
-version = "0.4.dev0"
+version = "0.5.dev0"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
@philipjusher Just saw the notification for release. Seems like the workflow is correctly set up !
Btw, next time try to release from a release branch (not sure you did that here). This will allow you to release extra patch releases later on if you require to (for example vulnerability fixes).