### PR TITLE
CHORE: Revert changelog changes after release failure

### DIFF
--- a/doc/changelog.d/106.changed.md
+++ b/doc/changelog.d/106.changed.md
@@ -1,0 +1,1 @@
+chore: update CHANGELOG for v0.4.0

--- a/doc/changelog.d/107.changed.md
+++ b/doc/changelog.d/107.changed.md
@@ -1,0 +1,1 @@
+CHORE: Bump development version to 0.5.dev0

--- a/doc/changelog.d/109.changed.md
+++ b/doc/changelog.d/109.changed.md
@@ -1,0 +1,1 @@
+BUILD: Update dependencies range

--- a/doc/changelog.d/110.changed.md
+++ b/doc/changelog.d/110.changed.md
@@ -1,1 +1,0 @@
-chore: update CHANGELOG for v0.4.1

--- a/doc/changelog.d/112.miscellaneous.md
+++ b/doc/changelog.d/112.miscellaneous.md
@@ -1,0 +1,1 @@
+CHORE: Revert changelog changes after release failure

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -9,16 +9,6 @@ This document contains the release notes for the project.
 
 .. towncrier release notes start
 
-`0.4.1 <https://github.com/ansys/pyconceptev/releases/tag/v0.4.1>`_ - 2024-09-12
-================================================================================
-
-Changed
-^^^^^^^
-
-- chore: update CHANGELOG for v0.4.0 `#106 <https://github.com/ansys/pyconceptev/pull/106>`_
-- CHORE: Bump development version to 0.5.dev0 `#107 <https://github.com/ansys/pyconceptev/pull/107>`_
-- BUILD: Update dependencies range `#109 <https://github.com/ansys/pyconceptev/pull/109>`_
-
 `0.4 <https://github.com/ansys/pyconceptev/releases/tag/v0.4>`_ - 2024-09-04
 ============================================================================
 


### PR DESCRIPTION
As title says. Release v0.4.1 failed for some reason.