### PR TITLE
ci: remove unused env variables

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,9 +11,6 @@ env:
   MAIN_PYTHON_VERSION: '3.14'
   PACKAGE_NAME: 'ansys-conceptev-core'
   DOCUMENTATION_CNAME: 'conceptev.docs.pyansys.com'
-  MEILISEARCH_API_KEY: ${{ secrets.MEILISEARCH_API_KEY }}
-  MEILISEARCH_HOST_URL: ${{ vars.MEILISEARCH_HOST_URL }}
-  MEILISEARCH_PUBLIC_API_KEY: ${{ secrets.MEILISEARCH_PUBLIC_API_KEY }}
 
 permissions: {}
 

--- a/doc/changelog.d/377.maintenance.md
+++ b/doc/changelog.d/377.maintenance.md
@@ -1,0 +1,1 @@
+Ci: remove unused env variables


### PR DESCRIPTION
Remove access to unneeded secrets and variables (MEILISEARCH). They should be removed from the organization level in the near future because we don't leverage meilisearch anymore.